### PR TITLE
Remove state type arguments from board functions

### DIFF
--- a/board.ml
+++ b/board.ml
@@ -38,16 +38,7 @@ type t = {
   size : int;
 }
 
-type current =
-  | InProgress
-  | Finished
-  | Pregame
 
-type state = {
-  turn : color;
-  board : t;
-  current : current;
-}
 
 exception EmptyStartSquare
 
@@ -177,7 +168,7 @@ let get_all_jumps sq brd clr =
   let right = get_jumps_d sq brd clr square_right in
   above @ left @ right
 
-let where_move brd sq (st : State.state) =
+let where_move brd sq turn =
   try
     let pc = Option.get sq.occupant in
     let pc_typ = pc.role in
@@ -190,12 +181,12 @@ let where_move brd sq (st : State.state) =
     else []
   with _ -> raise EmptyStartSquare
 
-let can_move square board (st : State.state) =
+let can_move square board turn =
   let condition1 = not (check_if_occupied square) in
   if square.occupant <> None then
     let pc = Option.get square.occupant in
-    let condition2 = pc.color = State.get_turn st in
-    let condition3 = where_move board square st <> [] in
+    let condition2 = pc.color = turn in
+    let condition3 = where_move board square turn <> [] in
     condition1 && condition2 && condition3
   else false
 

--- a/board.mli
+++ b/board.mli
@@ -32,13 +32,13 @@ val get_square : char * int -> t -> square
 (** [where_move board square] describes the squares where any given
     piece is allowed to move to, from its current position. This depends
     on it's piece type and current position, [square]. *)
-val where_move : t -> square -> State.state -> square list
+val where_move : t -> square -> color -> square list
 
 (** [can_move square board] describes whether or not a given piece
     occupying [square] is allowed to move based off of th rules of Dama.
     true = it can and false = it cannot. Assumes: It is the move of the
     color who's piece occupies [square]*)
-val can_move : square -> t -> State.state -> bool
+val can_move : square -> t -> color -> bool
 
 (* [get_jumps sq brd clr func] describes all possible locations the
    occupant of square [square] can jump as a list of squares going in

--- a/command.mli
+++ b/command.mli
@@ -1,25 +1,30 @@
-(* type square_label = char * int
+type square_label = char * int
 
-   (** The abstract data type that represents two squares on the board:
-   the starting square and the ending square in a move. *) type
-   squares_move = square_label * square_label
+(** The abstract data type that represents two squares on the board: the
+    starting square and the ending square in a move. *)
+type squares_move = square_label * square_label
 
-   (** The abstract data type representing a command. *) type command =
-   | Move of squares_move | Undo | Forfeit | Hint
+(** The abstract data type representing a command. *)
+type command =
+  | Move of squares_move
+  | Undo
+  | Forfeit
+  | Hint
 
-   (** Raised when the command is not in correct form. Correct forms
-   are: move followed by two strings, undo, forfeit, hint Each of these
-   commands can be separated with any number of spaces and can begin/end
-   with any number of spaces also *) exception IllegalCommand
+(** Raised when the command is not in correct form. Correct forms are:
+    move followed by two strings, undo, forfeit, hint Each of these
+    commands can be separated with any number of spaces and can
+    begin/end with any number of spaces also *)
+exception IllegalCommand
 
-   exception IllegalSquare
+exception IllegalSquare
 
-   (** Raised when no command is given or the command is empty. *)
-   exception NoCommand
+(** Raised when no command is given or the command is empty. *)
+exception NoCommand
 
-   (** Parses the command and returns the type of command, and if the
-   command is move, it returns a type Move of [squares_move].
+(** Parses the command and returns the type of command, and if the
+    command is move, it returns a type Move of [squares_move].
 
-   If no command is given raises NoCommand If command is not in the
-   correct form an IllegalCommand is raised. *) val parse : string ->
-   command *)
+    If no command is given raises NoCommand If command is not in the
+    correct form an IllegalCommand is raised. *)
+val parse : string -> command

--- a/state.ml
+++ b/state.ml
@@ -1,3 +1,14 @@
-type state = { state : string }
+type current =
+  | InProgress
+  | Finished
+  | Pregame
+
+type state = {
+  turn : Board.color;
+  board : Board.t;
+  current : current;
+}
 
 let get_turn = failwith "Unimplemented"
+
+let update_state_move board command = failwith "Unimplemented"

--- a/state.mli
+++ b/state.mli
@@ -1,5 +1,7 @@
 type state
 
+type current
+
 val get_turn : state -> _
 
-(* val update_state : Board.t -> Command.command -> state *)
+val update_state_move : Board.t -> Command.squares_move -> _


### PR DESCRIPTION
We don't need the whole state type to be passed as an argument for move functions. This causes issues when defining functions in the state module that require the use of board types. 

It causes this error: `Circular build detected (board.cmi already seen in [ state.cmi; board.cmi ])`

Fixed this by passing `turn` to move functions which is of type `color`